### PR TITLE
fix #118: zuuu_version is now printed

### DIFF
--- a/mobile_base_controller/zuuu_hal/zuuu_hal/zuuu_hal.py
+++ b/mobile_base_controller/zuuu_hal/zuuu_hal/zuuu_hal.py
@@ -158,6 +158,7 @@ class ZuuuHAL(Node):
         #     os.path.expanduser('~')+'/.local/bin/reachy-identify-zuuu-model'
         #     ).strip().decode()
         self.zuuu_model = get_zuuu_version()
+        self.get_logger().info(f"zuuu version: {self.zuuu_model}")
         try:
             float_model = float(self.zuuu_model)
             if float_model < 1.0:


### PR DESCRIPTION
Minor fix: added a print in zuuu_hal to show the zuuu_version read in the .reachy.yaml file