### PR TITLE
Use reachy_utils to get zuuu_version.

### DIFF
--- a/mobile_base_controller/mobile_base_sdk_server/mobile_base_sdk_server/mobile_base_sdk_server.py
+++ b/mobile_base_controller/mobile_base_sdk_server/mobile_base_sdk_server/mobile_base_sdk_server.py
@@ -18,6 +18,8 @@ from zuuu_interfaces.srv import SetZuuuMode, GetZuuuMode, GetOdometry, ResetOdom
 from zuuu_interfaces.srv import GoToXYTheta, DistanceToGoal, SetZuuuSafety
 from zuuu_interfaces.srv import SetSpeed, GetBatteryVoltage
 
+from reachy_utils.config import get_zuuu_version
+
 
 class MobileBaseServer(
                         Node,
@@ -287,11 +289,11 @@ class MobileBaseServer(
         presence = False
         version = '0.0'
 
-        model = check_output(['reachy-identify-zuuu-model']).strip().decode()
+        model = get_zuuu_version()
 
         if model and model != 'None':
             presence = True
-            version = float(model)
+            version = model
 
         response = mobile_platform_reachy_pb2.MobileBasePresence(
             presence=BoolValue(value=presence),

--- a/mobile_base_controller/zuuu_hal/zuuu_hal/__init__.py
+++ b/mobile_base_controller/zuuu_hal/zuuu_hal/__init__.py
@@ -1,7 +1,0 @@
-def identify_zuuu_model():
-    import yaml
-    import os
-    config_file = os.path.expanduser('~/.reachy.yaml')
-    with open(config_file) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
-        return config['zuuu_version']

--- a/mobile_base_controller/zuuu_hal/zuuu_hal/lidar_safety.py
+++ b/mobile_base_controller/zuuu_hal/zuuu_hal/lidar_safety.py
@@ -8,7 +8,7 @@ from typing import List
 from sensor_msgs.msg import LaserScan
 
 from zuuu_hal.utils import angle_diff
-from zuuu_hal import identify_zuuu_model
+from reachy_utils.config import get_zuuu_version
 
 
 class LidarSafety:
@@ -33,19 +33,18 @@ class LidarSafety:
         self.critical_angles = []
         self.at_least_one_critical = False
         self.logger = logger
-        zuuu_model = identify_zuuu_model()
-        # zuuu_model = check_output(os.path.expanduser('~')+'/.local/bin/reachy-identify-zuuu-model').strip().decode()
+        zuuu_version = get_zuuu_version()
 
         # Not using the TF transforms because this is faster
         # TODO use a static TF2 transform instead
         try:
-            float_model = float(zuuu_model)
+            float_model = float(zuuu_version)
             if float_model < 1.0:
                 self.x_offset = 0.155
             else:
                 self.x_offset = 0.1815
         except Exception:
-            msg = "ZUUU version can't be processed, check that the 'zuuu_model' tag is "\
+            msg = "ZUUU version can't be processed, check that the 'zuuu_version' tag is "\
                 "present in the .reachy.yaml file"
             self.logger.error(msg)
             self.logger.error(traceback.format_exc())

--- a/mobile_base_controller/zuuu_hal/zuuu_hal/zuuu_hal.py
+++ b/mobile_base_controller/zuuu_hal/zuuu_hal/zuuu_hal.py
@@ -56,7 +56,6 @@ from zuuu_interfaces.srv import SetSpeed, GetBatteryVoltage, SetZuuuSafety
 
 from zuuu_hal.utils import PID, angle_diff, sign
 from zuuu_hal.lidar_safety import LidarSafety
-from zuuu_hal import identify_zuuu_model
 from reachy_utils.config import get_zuuu_version
 
 
@@ -157,10 +156,10 @@ class ZuuuHAL(Node):
         # self.zuuu_model = check_output(
         #     os.path.expanduser('~')+'/.local/bin/reachy-identify-zuuu-model'
         #     ).strip().decode()
-        self.zuuu_model = get_zuuu_version()
-        self.get_logger().info(f"zuuu version: {self.zuuu_model}")
+        self.zuuu_version = get_zuuu_version()
+        self.get_logger().info(f"zuuu version: {self.zuuu_version}")
         try:
-            float_model = float(self.zuuu_model)
+            float_model = float(self.zuuu_version)
             if float_model < 1.0:
                 self.omnibase = MobileBase(left_wheel_id=24, right_wheel_id=72, back_wheel_id=None)
             elif float_model < 1.2:
@@ -168,7 +167,7 @@ class ZuuuHAL(Node):
             else:
                 self.omnibase = MobileBase(left_wheel_id=None, right_wheel_id=72, back_wheel_id=116)
         except Exception:
-            msg = "ZUUU version can't be processed, check that the 'zuuu_model' tag is "\
+            msg = "ZUUU version can't be processed, check that the 'zuuu_version' tag is "\
                 "present in the .reachy.yaml file"
             self.get_logger().error(msg)
             self.get_logger().error(traceback.format_exc())


### PR DESCRIPTION
- Due to the use of reachy_config instead of identify-zuuu-model in reachy 2021, getting the mobile base version with the mobile-base-sdk was not working anymore
- Tested on a mobile base