### PR TITLE
Dashboard compatibility

### DIFF
--- a/reachy_bringup/launch/reachy.launch.py
+++ b/reachy_bringup/launch/reachy.launch.py
@@ -20,6 +20,11 @@ REACHY_CONFIG_BOTTOM = "bottom"
 REACHY_CONFIG_MIDDLE = "middle"
 
 
+# Before launching each node, scan the usb2ax to check if there are any missing motors
+from reachy_utils.discovery import get_missing_motors_reachy
+get_missing_motors_reachy(check_service=False)
+
+
 class ReachyConfig:
     def __init__(self, config_file_path='~/.reachy.yaml'):
 

--- a/reachy_utils/reachy_utils/config.py
+++ b/reachy_utils/reachy_utils/config.py
@@ -23,6 +23,7 @@ def _get_config_parameter(parameter: str, part=None):
 
 get_reachy_generation = partial(_get_config_parameter, "generation")
 get_reachy_model = partial(_get_config_parameter, "model")
+get_reachy_serial_number = partial(_get_config_parameter, "serial_number")
 get_zuuu_version = partial(_get_config_parameter, "zuuu_version")
 get_neck_orbita_zero = partial(_get_config_parameter, "neck_orbita_zero")
 get_camera_parameters = partial(_get_config_parameter, "camera_parameters")

--- a/reachy_utils/reachy_utils/discovery.py
+++ b/reachy_utils/reachy_utils/discovery.py
@@ -111,7 +111,7 @@ def _init_missing_motors():
     return missing_motors_init
 
 
-def get_missing_motors_reachy():
+def get_missing_motors_reachy(check_service: bool = True):
     reachy_model = get_reachy_model()
     missing_motors = _init_missing_motors()
     service_was_active = False
@@ -123,12 +123,13 @@ def get_missing_motors_reachy():
     )
     status = pipe.stdout.decode().split()
 
-    if status[0] == "active":
-        service_was_active = True
-        print("Disabling reachy_sdk_server.service to access the usb2ax boards.")
-        run(
-            ["systemctl --user stop reachy_sdk_server.service"], stdout=PIPE, shell=True
-        )
+    if check_service:
+        if status[0] == "active":
+            service_was_active = True
+            print("Disabling reachy_sdk_server.service to access the usb2ax boards.")
+            run(
+                ["systemctl --user stop reachy_sdk_server.service"], stdout=PIPE, shell=True
+            )
 
     for part in robot_config_to_parts[reachy_model]:
         if "arm" in part:

--- a/reachy_utils/reachy_utils/discovery.py
+++ b/reachy_utils/reachy_utils/discovery.py
@@ -144,7 +144,7 @@ def get_missing_motors_reachy(check_service: bool = True):
                 ["systemctl --user start reachy_sdk_server.service"], stdout=PIPE, shell=True
         )
 
-    with open(_latest_discovery_file, 'w')as f:
+    with open(_latest_discovery_file, 'w') as f:
         yaml.dump(missing_motors, f)
 
     return missing_motors

--- a/reachy_utils/reachy_utils/discovery.py
+++ b/reachy_utils/reachy_utils/discovery.py
@@ -1,8 +1,13 @@
-from pypot.dynamixel import DxlIO, Dxl320IO
-from reachy_utils.config import get_reachy_model
+import os
 from serial import SerialException
 from subprocess import run, PIPE
 from typing import Dict
+import yaml
+
+from pypot.dynamixel import DxlIO, Dxl320IO
+from reachy_utils.config import get_reachy_model
+
+_latest_discovery_file = os.path.expanduser("~/.reachy-latest-discovery.yaml")
 
 
 motor_ids_per_part = {
@@ -137,6 +142,9 @@ def get_missing_motors_reachy():
         run(
                 ["systemctl --user start reachy_sdk_server.service"], stdout=PIPE, shell=True
         )
+
+    with open(_latest_discovery_file, 'w')as f:
+        yaml.dump(missing_motors, f)
 
     return missing_motors
 

--- a/reachy_utils/reachy_utils/files/.reachy.yaml
+++ b/reachy_utils/reachy_utils/files/.reachy.yaml
@@ -1,6 +1,7 @@
 generation: 2023
 model: full_kit
 zuuu_version: 1.2
+serial_number: todo
 neck_orbita_zero:
     top: 0.0
     middle: 0.0


### PR DESCRIPTION
- The results of the latest discovery is now stored in a file ~/.reachy-latest-discovery.yaml. Having access to this file allows to display the missing motors when accessing the main dashboard page from the dashboard without having to disable reachy_sdk_server.service to access the usb2ax boards twice.
- Added the serial number of the robot in .reachy.yaml file