### PR TITLE
Bug #215: use package:// in xacro

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Now you can add the following lines to your bashrc
 ```commandline
 source ~/reachy_ws/install/setup.bash
 source /usr/share/gazebo/setup.bash
+export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:<your path>/reachy_ws/src/reachy_2023
 ```
 
 If there is multiple ROS2 environement on the same network, you should think about using adding ROS_DOMAIN_ID yo your

--- a/reachy_description/urdf/arm.urdf.xacro
+++ b/reachy_description/urdf/arm.urdf.xacro
@@ -22,7 +22,7 @@
             <visual name="">
                 <origin xyz="0.0 ${0.04*reflect} 0.0" rpy="${1.57*reflect} 1.57 0.0"/>
                 <geometry>
-                    <mesh filename="file://$(find reachy_description)/meshes/shoulder.dae"/>
+                    <mesh filename="package://reachy_description/meshes/shoulder.dae"/>
                 </geometry>
             </visual>
             <collision>
@@ -51,7 +51,7 @@
             <visual name="">
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
                 <geometry>
-                    <mesh filename="file://$(find reachy_description)/meshes/shoulder_x.dae"/>
+                    <mesh filename="package://reachy_description/meshes/shoulder_x.dae"/>
                 </geometry>
             </visual>
             <collision>
@@ -85,7 +85,7 @@
             <visual name="">
                 <origin xyz="0.0 0.0 -0.0526" rpy="0.0 0.0 0.0"/>
                 <geometry>
-                    <mesh filename="file://$(find reachy_description)/meshes/upper_arm.dae"/>
+                    <mesh filename="package://reachy_description/meshes/upper_arm.dae"/>
                 </geometry>
             </visual>
             <collision>
@@ -114,7 +114,7 @@
             <visual name="">
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
                 <geometry>
-                    <mesh filename="file://$(find reachy_description)/meshes/forearm.dae"/>
+                    <mesh filename="package://reachy_description/meshes/forearm.dae"/>
                 </geometry>
             </visual>
             <collision>
@@ -143,7 +143,7 @@
             <visual name="">
                 <origin xyz="0.0 0.0 -0.100" rpy="0.0 0.0 0.0"/>
                 <geometry>
-                    <mesh filename="file://$(find reachy_description)/meshes/wrist.dae"/>
+                    <mesh filename="package://reachy_description/meshes/wrist.dae"/>
                 </geometry>
             </visual>
             <collision>
@@ -182,7 +182,7 @@
             <visual name="">
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
                 <geometry>
-                    <mesh filename="file://$(find reachy_description)/meshes/wrist2hand.dae"/>
+                    <mesh filename="package://reachy_description/meshes/wrist2hand.dae"/>
                 </geometry>
             </visual>
             <collision>
@@ -230,13 +230,13 @@
             <visual name="">
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 1.57 0.0"/>
                 <geometry>
-                    <mesh filename="file://$(find reachy_description)/meshes/${prefix}_gripper_thumb.dae"/>
+                    <mesh filename="package://reachy_description/meshes/${prefix}_gripper_thumb.dae"/>
                 </geometry>
             </visual>
             <collision>
                 <!-- <origin xyz="0.0 0.0 0.0" rpy="0.0 1.57 0.0"/> -->
                 <!-- <geometry> -->
-                <!-- <mesh filename="file://$(find reachy_description)/meshes/${prefix}_gripper_thumb.dae"/> -->
+                <!-- <mesh filename="package://reachy_description/meshes/${prefix}_gripper_thumb.dae"/> -->
                 <!-- </geometry> -->
                 <origin xyz="0.0 ${0.02 *reflect} -0.06" rpy="-0.17 1.57 0.0"/>
                 <geometry>
@@ -292,13 +292,13 @@
             <visual name="">
                 <origin xyz="0.0 0.0 0.0" rpy="0.0 1.57 0.0"/>
                 <geometry>
-                    <mesh filename="file://$(find reachy_description)/meshes/${prefix}_gripper_finger.dae"/>
+                    <mesh filename="package://reachy_description/meshes/${prefix}_gripper_finger.dae"/>
                 </geometry>
             </visual>
             <collision>
                 <!-- <origin xyz="0.0 0.0 0.0" rpy="0.0 1.57 0.0"/> -->
                 <!-- <geometry> -->
-                <!-- <mesh filename="file://$(find reachy_description)/meshes/${prefix}_gripper_finger.dae"/> -->
+                <!-- <mesh filename="package://reachy_description/meshes/${prefix}_gripper_finger.dae"/> -->
                 <!-- </geometry> -->
                 <origin xyz="0.0 ${-0.01*reflect} -0.02" rpy="0.17 1.57 0.0"/>
                 <geometry>

--- a/reachy_description/urdf/head.urdf.xacro
+++ b/reachy_description/urdf/head.urdf.xacro
@@ -84,7 +84,7 @@
       <visual name="">
         <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.5236"/>
         <geometry>
-          <mesh filename="file://$(find reachy_description)/meshes/orbita_arm.dae"/>
+          <mesh filename="package://reachy_description/meshes/orbita_arm.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -110,7 +110,7 @@
       <visual name="">
         <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 2.618"/>
         <geometry>
-          <mesh filename="file://$(find reachy_description)/meshes/orbita_arm.dae"/>
+          <mesh filename="package://reachy_description/meshes/orbita_arm.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -136,7 +136,7 @@
       <visual name="">
         <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 -1.57"/>
         <geometry>
-          <mesh filename="file://$(find reachy_description)/meshes/orbita_arm.dae"/>
+          <mesh filename="package://reachy_description/meshes/orbita_arm.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -158,7 +158,7 @@
       <visual name="">
         <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="file://$(find reachy_description)/meshes/head.dae"/>
+          <mesh filename="package://reachy_description/meshes/head.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -195,7 +195,7 @@
       <visual name="">
         <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="file://$(find reachy_description)/meshes/antenna.dae"/>
+          <mesh filename="package://reachy_description/meshes/antenna.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -223,7 +223,7 @@
       <visual name="">
         <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="file://$(find reachy_description)/meshes/antenna.dae"/>
+          <mesh filename="package://reachy_description/meshes/antenna.dae"/>
         </geometry>
       </visual>
       <collision>

--- a/reachy_description/urdf/meshed_arm.urdf.xacro
+++ b/reachy_description/urdf/meshed_arm.urdf.xacro
@@ -22,7 +22,7 @@
       <visual name="">
           <origin xyz="0.0 ${0.04*reflect} 0.0" rpy="${1.57*reflect} 1.57 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/shoulder.dae"/>
+              <mesh filename="package://reachy_description/meshes/shoulder.dae"/>
           </geometry>
       </visual>
       <collision>
@@ -51,7 +51,7 @@
       <visual name="">
           <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/shoulder_x.dae"/>
+              <mesh filename="package://reachy_description/meshes/shoulder_x.dae"/>
           </geometry>
       </visual>
       <collision>
@@ -85,7 +85,7 @@
       <visual name="">
           <origin xyz="0.0 0.0 -0.0526" rpy="0.0 0.0 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/upper_arm.dae"/>
+              <mesh filename="package://reachy_description/meshes/upper_arm.dae"/>
           </geometry>
       </visual>
       <collision>
@@ -114,7 +114,7 @@
       <visual name="">
           <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/forearm.dae"/>
+              <mesh filename="package://reachy_description/meshes/forearm.dae"/>
           </geometry>
       </visual>
       <collision>
@@ -143,7 +143,7 @@
       <visual name="">
           <origin xyz="0.0 0.0 -0.100" rpy="0.0 0.0 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/wrist.dae"/>
+              <mesh filename="package://reachy_description/meshes/wrist.dae"/>
           </geometry>
       </visual>
       <collision>
@@ -172,7 +172,7 @@
       <visual name="">
           <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/wrist2hand.dae"/>
+              <mesh filename="package://reachy_description/meshes/wrist2hand.dae"/>
           </geometry>
       </visual>
       <collision>
@@ -201,13 +201,13 @@
       <visual name="">
           <origin xyz="0.0 0.0 0.0" rpy="0.0 1.57 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/${prefix}_gripper_thumb.dae"/>
+              <mesh filename="package://reachy_description/meshes/${prefix}_gripper_thumb.dae"/>
           </geometry>
       </visual>
       <collision>
           <origin xyz="0.0 0.0 0.0" rpy="0.0 1.57 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/${prefix}_gripper_thumb.dae"/>
+              <mesh filename="package://reachy_description/meshes/${prefix}_gripper_thumb.dae"/>
           </geometry>
           <!-- <origin xyz="0.0 0.02 -0.06" rpy="0.0 1.57 0.0"/> -->
           <!-- <geometry> -->
@@ -247,13 +247,13 @@
       <visual name="">
           <origin xyz="0.0 0.0 0.0" rpy="0.0 1.57 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/${prefix}_gripper_finger.dae"/>
+              <mesh filename="package://reachy_description/meshes/${prefix}_gripper_finger.dae"/>
           </geometry>
       </visual>
       <collision>
           <origin xyz="0.0 0.0 0.0" rpy="0.0 1.57 0.0"/>
           <geometry>
-              <mesh filename="file://$(find reachy_description)/meshes/${prefix}_gripper_finger.dae"/>
+              <mesh filename="package://reachy_description/meshes/${prefix}_gripper_finger.dae"/>
           </geometry>
           <!-- <origin xyz="0.0 ${-0.01*reflect} -0.02" rpy="0.0 1.57 0.0"/> -->
           <!-- <geometry> -->

--- a/reachy_description/urdf/reachy.urdf.xacro
+++ b/reachy_description/urdf/reachy.urdf.xacro
@@ -26,7 +26,7 @@
         <visual name="">
             <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
             <geometry>
-                <mesh filename="file://$(find reachy_description)/meshes/torso.dae"/>
+                <mesh filename="package://reachy_description/meshes/torso.dae"/>
             </geometry>
         </visual>
         <collision>


### PR DESCRIPTION
I use package:// instead of file:// $find etc.
This way a ROS viewer located in another computer will be able to display Reachy.
Gazebo needs to have the GAZEBO_MODEL_PATH configured to be able to interpret this path.