### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ mkdir ~/reachy_ws && cd ~/reachy_ws
 mkdir src && cd src
 git clone https://github.com/pollen-robotics/reachy_2023.git
 ```
+### Copy the configuration file
+```commandline
+cp ~/reachy_ws/src/reachy_2023/reachy_utils/reachy_utils/files.reachy.yaml ~/
+```
 
 ### Build Reachy_2023 env
 


### PR DESCRIPTION
Small README update to indicate that the .reachy.yaml file must be copied in ~/ for the stack to run